### PR TITLE
Update VS Code in package.json to match ide/pnpm-lock.yaml

### DIFF
--- a/ide/packages/extension/package.json
+++ b/ide/packages/extension/package.json
@@ -7,7 +7,7 @@
   "icon": "argus-logo-128.png",
   "version": "0.1.15",
   "engines": {
-    "vscode": "^1.79.0"
+    "vscode": "^1.99.1"
   },
   "bugs": {
     "url": "https://github.com/cognitive-engineering-lab/argus/issues",


### PR DESCRIPTION
Since the lockfile refers to 1.99.1 ([source](https://github.com/cognitive-engineering-lab/argus/blob/734fb41c41b78537aa9ec5ea0167f59fd619e977/ide/pnpm-lock.yaml#L131)), it seems like the issues that motivated this change probably are more than just a quirk of my own setup.